### PR TITLE
Add modern development and zsh tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,36 @@ Nix の管理対象外です。`homebrew.user = "alice"` は Homebrew を実行�
 - macOS Application Firewall、stealth mode、Wake-on-LAN
 - スリープ無効、停電復帰後の自動起動
 
+## Zsh
+
+system-wide の zsh 設定として、Powerlevel10k、補完、autosuggestions、syntax
+highlighting、fzf 履歴検索、zoxide を有効にしています。Meslo Nerd Font も Nix で
+導入します。p10k の表示内容はユーザーごとの `~/.p10k.zsh` に保存され、Nix の
+管理対象外です。初回適用後に次を実行してください。
+
+```sh
+p10k configure
+```
+
+`g` を実行すると、`ghq` が管理するリポジトリを `peco` で絞り込み、その
+ディレクトリへ移動します。この操作は
+[Findy Media の ghq + peco の例](https://findy-code.io/media/articles/aisaji-tonkotsuboy_com#%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E9%96%93%E3%82%92%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E4%B8%80%E3%81%A4%E3%81%A7%E7%A7%BB%E5%8B%95%E3%81%99%E3%82%8Bghq-peco)
+を、キャンセルと空白入りパスを安全に扱えるよう調整したものです。
+
+```sh
+ghq get 6uclz1/dotfiles
+g
+```
+
+主な操作:
+
+- `Ctrl-R`: fzf による履歴検索
+- `Ctrl-G`: fzf による Git オブジェクト検索
+- `ll`: Git 情報付きの詳細ファイル一覧
+- `lt`: 2階層のツリー表示
+- `lg`: lazygit
+- `v`: Neovim
+
 ## 新しい Mac mini への復元
 
 ### 1. macOS の準備

--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ Nix の管理対象外です。`homebrew.user = "alice"` は Homebrew を実行�
 ## 管理しているもの
 
 - Determinate Nix と macOS build sandbox
-- `age`、`bat`、`bottom`、`fd`、`gh`、`git`、`jq`、`just`、
-  `restic`、`ripgrep`、`shellcheck`、`sops`、`tmux`、`tree`、`watch`
+- 開発・Git: `gh`、`ghq`、`git`、`delta`、`lazygit`、`direnv`、`just`
+- 検索・ファイル操作: `ripgrep`、`fd`、`fzf`、`eza`、`bat`、`sd`
+- データ・Web: `jq`、`yq`、`ax`
+- 監視・計測: `bottom`、`procs`、`dust`、`dua`、`hyperfine`
+- 運用: `age`、`restic`、`shellcheck`、`sops`、`tealdeer`、`tmux`、
+  `tree`、`watch`、`zoxide`
 - Homebrew の `smartmontools` と Ghostty
 - 公開鍵認証のみの SSH（Tailscale のアドレス範囲からだけ接続可能。鍵は管理外）
 - AdGuard Home 0.107.78（Apple Silicon 版を SHA-256 で固定）

--- a/configuration.nix
+++ b/configuration.nix
@@ -34,6 +34,8 @@ let
   };
 in
 {
+  imports = [ ./zsh.nix ];
+
   # Determinate Nix owns the Nix daemon and Nix configuration. Enabling this
   # module prevents nix-darwin from trying to manage the same settings.
   determinateNix = {
@@ -89,7 +91,6 @@ in
     zoxide
   ];
 
-  programs.zsh.enable = true;
   programs.direnv.enable = true;
 
   # Keep the built-in macOS SSH daemon reachable only from Tailscale.

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,6 +1,13 @@
-{ pkgs, self, ... }:
+{
+  inputs,
+  pkgs,
+  self,
+  ...
+}:
 
 let
+  ax = inputs.ax.packages.${pkgs.stdenv.hostPlatform.system}.default;
+
   # Pin the vendor's stable Apple Silicon release and verify the published
   # archive checksum. AdGuard Home's own updater is disabled because upgrades
   # belong in a reviewed flake change.
@@ -52,20 +59,34 @@ in
   environment.systemPackages = with pkgs; [
     age
     adguardHome
+    ax
     bat
     bottom
+    delta
+    dua
+    dust
+    eza
     fd
+    fzf
     gh
+    ghq
     git
+    hyperfine
     jq
     just
+    lazygit
+    procs
     restic
     ripgrep
+    sd
     shellcheck
     sops
+    tealdeer
     tmux
     tree
     watch
+    yq-go
+    zoxide
   ];
 
   programs.zsh.enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,51 @@
 {
   "nodes": {
+    "ax": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785906402,
+        "narHash": "sha256-2F416Szv3Y5cHUB2yOKYKJeHDp7XChG11Lj/zIXsPKc=",
+        "owner": "yusukebe",
+        "repo": "ax",
+        "rev": "0ddd8a748ae2401ae344f536f6e8dded890fcdbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusukebe",
+        "ref": "v0.1.25",
+        "repo": "ax",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "ax",
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1784665499,
+        "narHash": "sha256-9BMxlTxCCDAeoNLtb1a/st7udtTIJep+wpUzquA29VU=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "0f2a1f0b6f42cebe3b149bf62d38754c5e0e9729",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "determinate": {
       "inputs": {
         "determinate-nixd-aarch64-darwin": "determinate-nixd-aarch64-darwin",
@@ -76,6 +122,28 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
+          "ax",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
           "determinate",
           "nix",
           "nixpkgs"
@@ -118,7 +186,7 @@
     },
     "nix": {
       "inputs": {
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "git-hooks-nix": "git-hooks-nix",
         "nixpkgs": "nixpkgs",
         "nixpkgs-23-11": "nixpkgs-23-11",
@@ -232,9 +300,47 @@
     },
     "root": {
       "inputs": {
+        "ax": "ax",
         "determinate": "determinate",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs_3"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1776166891,
+        "narHash": "sha256-bI8yrEGjrohR5hkQox7UrxDH7XqrYMwI8SL/LrJ1+S8=",
+        "owner": "nix-systems",
+        "repo": "triplet",
+        "rev": "6de7bc09397911ce03636afbcf6118745ab2cda0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "triplet",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "ax",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -5,21 +5,35 @@
     determinate.url = "https://flakehub.com/f/DeterminateSystems/determinate/3";
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0";
 
+    ax = {
+      url = "github:yusukebe/ax/v0.1.25";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     nix-darwin = {
       url = "https://flakehub.com/f/nix-darwin/nix-darwin/0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = inputs@{ self, nix-darwin, ... }: {
-    # This is a flake selector, not the macOS hostname. The flake deliberately
-    # leaves ComputerName, HostName, and LocalHostName unmanaged.
-    darwinConfigurations."mac-mini" = nix-darwin.lib.darwinSystem {
-      specialArgs = { inherit inputs self; };
-      modules = [
-        inputs.determinate.darwinModules.default
-        ./configuration.nix
-      ];
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      nix-darwin,
+      ...
+    }:
+    {
+      # This is a flake selector, not the macOS hostname. The flake deliberately
+      # leaves ComputerName, HostName, and LocalHostName unmanaged.
+      darwinConfigurations."mac-mini" = nix-darwin.lib.darwinSystem {
+        specialArgs = { inherit inputs self; };
+        modules = [
+          inputs.determinate.darwinModules.default
+          ./configuration.nix
+        ];
+      };
+
+      formatter.aarch64-darwin = nixpkgs.legacyPackages.aarch64-darwin.nixfmt;
     };
-  };
 }

--- a/zsh.nix
+++ b/zsh.nix
@@ -1,0 +1,77 @@
+{ pkgs, ... }:
+
+{
+  fonts.packages = [ pkgs.nerd-fonts.meslo-lg ];
+
+  environment = {
+    systemPackages = with pkgs; [
+      neovim
+      peco
+      zsh-powerlevel10k
+    ];
+
+    shellAliases = {
+      cat = "bat --paging=never";
+      l = "eza --group-directories-first";
+      la = "eza --all --group-directories-first";
+      ll = "eza --long --all --git --group-directories-first";
+      lt = "eza --tree --level=2 --group-directories-first";
+      lg = "lazygit";
+      v = "nvim";
+    };
+  };
+
+  programs.zsh = {
+    enable = true;
+    enableCompletion = true;
+    enableAutosuggestions = true;
+    enableSyntaxHighlighting = true;
+    enableFzfCompletion = true;
+    enableFzfGit = true;
+    enableFzfHistory = true;
+
+    histFile = "$HOME/.zsh_history";
+    histSize = 1000000;
+
+    variables = {
+      EDITOR = "nvim";
+      VISUAL = "nvim";
+      HOMEBREW_NO_ANALYTICS = "1";
+    };
+
+    interactiveShellInit = ''
+      setopt AUTO_CD
+      setopt AUTO_PUSHD
+      setopt EXTENDED_HISTORY
+      setopt HIST_IGNORE_ALL_DUPS
+      setopt HIST_IGNORE_SPACE
+      setopt HIST_REDUCE_BLANKS
+      setopt HIST_SAVE_NO_DUPS
+      setopt INTERACTIVE_COMMENTS
+      setopt NO_BEEP
+      setopt PUSHD_IGNORE_DUPS
+      setopt PUSHD_SILENT
+
+      zstyle ':completion:*' menu select
+      zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}'
+      zstyle ':completion:*' list-colors "''${(s.:.)LS_COLORS}"
+
+      REPORTTIME=3
+
+      # Select a repository managed by ghq and move to it. The current command
+      # line is used as peco's initial query, following the referenced workflow.
+      function g() {
+        local selected_dir
+        selected_dir="$(ghq list --full-path | peco --query "$LBUFFER")" || return
+        [[ -n "$selected_dir" ]] && builtin cd -- "$selected_dir"
+      }
+
+      eval "$(zoxide init zsh)"
+    '';
+
+    promptInit = ''
+      source ${pkgs.zsh-powerlevel10k}/share/zsh-powerlevel10k/powerlevel10k.zsh-theme
+      [[ ! -r "$HOME/.p10k.zsh" ]] || source "$HOME/.p10k.zsh"
+    '';
+  };
+}


### PR DESCRIPTION
## What changed

- add a modern CLI toolset including ghq, eza, fzf, delta, lazygit, zoxide, dust, procs, yq, and related utilities
- pin yusukebe/ax v0.1.25 through its official Nix flake
- add a system-wide zsh configuration with Powerlevel10k, Meslo Nerd Font, completion, autosuggestions, syntax highlighting, and fzf widgets
- add a safe `g` function for selecting ghq repositories with peco
- add useful aliases, expanded history, Neovim, and shell defaults
- document the tools, shortcuts, p10k setup, and ghq workflow

## Why

The Mac mini configuration had the server foundation but lacked the interactive development workflow available in the earlier dotfiles. This restores the useful parts without bringing back Home Manager or managing the macOS user account.

## Validation

- `nix flake check --no-build`
- `nix build .#darwinConfigurations.mac-mini.system --no-link --print-out-paths`
- generated `/etc/zshrc` checked with `zsh -n`
- verified p10k, peco, Neovim, aliases, zoxide, autosuggestions, syntax highlighting, and fzf integrations in the built system
- secret-pattern scan and `git diff --check`

The validated system closure is `/nix/store/bcs28mpiskg8vkkd9gyfhsdykwjh9nsm-darwin-system-26.05.c3e90c8`.
